### PR TITLE
Allow to specify the action name extractor

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -227,6 +227,7 @@ func (m *middleware) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 func (m *middleware) newRequest(req *http.Request, res http.ResponseWriter) *request {
 	return &request{
 		middleware: m,
+		actionName: m.ActionNameExtractor(req),
 		request:    req,
 		response:   res,
 		logLines:   []interface{}{},
@@ -261,7 +262,7 @@ func SetLogjamHeaders(hasContext HasContext, outgoing *http.Request) {
 		incomingHeaders = incoming.Header
 	case *request:
 		incomingHeaders = incoming.request.Header
-		outgoing.Header.Set("X-Logjam-Request-Action", incoming.actionName())
+		outgoing.Header.Set("X-Logjam-Request-Action", incoming.actionName)
 		outgoing.Header.Set("X-Logjam-Request-Id", incoming.id())
 	default:
 		return

--- a/middleware.go
+++ b/middleware.go
@@ -44,7 +44,7 @@ const (
 	UNKNOWN LogLevel = iota
 )
 
-type ActionNameFunc func(*http.Request) string
+type ActionNameExtractor func(*http.Request) string
 
 // The Options can be passed to NewMiddleware.
 type Options struct {
@@ -54,7 +54,7 @@ type Options struct {
 	RandomSource        io.Reader   // If you want a deterministic RNG for UUIDs, set this.
 	Clock               clock.Clock // If you want to be a timelord, set this.
 	Logger              Logger
-	ActionNameExtractor ActionNameFunc
+	ActionNameExtractor ActionNameExtractor
 }
 
 // Logger must provide some methods to let Logjam output its logs.

--- a/middleware.go
+++ b/middleware.go
@@ -202,6 +202,7 @@ func (m *middleware) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	req = r.request.WithContext(context.WithValue(req.Context(), requestKey, r))
 	r.request = req
 
+	m.Logger.Println("LOGJAM start request")
 	r.start()
 
 	defer func() {
@@ -212,6 +213,7 @@ func (m *middleware) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}()
 
 	metrics := httpsnoop.CaptureMetrics(m.handler, res, req)
+	m.Logger.Println("LOGJAM finish request: ", metrics)
 	r.finish(metrics)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -211,7 +211,6 @@ func (m *middleware) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	req = r.request.WithContext(context.WithValue(req.Context(), requestKey, r))
 	r.request = req
 
-	m.Logger.Println("LOGJAM start request")
 	r.start()
 
 	defer func() {
@@ -222,7 +221,6 @@ func (m *middleware) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}()
 
 	metrics := httpsnoop.CaptureMetrics(m.handler, res, req)
-	m.Logger.Println("LOGJAM finish request: ", metrics)
 	r.finish(metrics)
 }
 

--- a/request.go
+++ b/request.go
@@ -21,7 +21,7 @@ type request struct {
 	request    *http.Request
 	response   http.ResponseWriter
 
-	cachedActionName   string
+	actionName         string
 	cachedUUID         string
 	startTime          time.Time
 	endTime            time.Time
@@ -31,22 +31,13 @@ type request struct {
 	statCounts         map[string]int64
 }
 
-func (r *request) actionName() string {
-	if r.cachedActionName != "" {
-		return r.cachedActionName
-	}
-
-	r.cachedActionName = r.middleware.ActionNameExtractor(r.request)
-	return r.cachedActionName
-}
-
 func (r *request) start() {
 	r.statDurations = map[string]time.Duration{}
 	r.statCounts = map[string]int64{}
 	r.startTime = r.middleware.Clock.Now()
 	header := r.response.Header()
 	header.Set("X-Logjam-Request-Id", r.id())
-	header.Set("X-Logjam-Request-Action", r.actionName())
+	header.Set("X-Logjam-Request-Action", r.actionName)
 	header.Set("X-Logjam-Caller-Id", r.request.Header.Get("X-Logjam-Caller-Id"))
 }
 
@@ -164,7 +155,7 @@ func (m *message) setCounts(counts map[string]int64) {
 
 func (r *request) payloadMessage(code int, host string) *message {
 	msg := &message{
-		Action:      r.actionName(),
+		Action:      r.actionName,
 		Code:        code,
 		IP:          obfuscateIP(host),
 		Lines:       r.logLines,

--- a/request.go
+++ b/request.go
@@ -36,7 +36,7 @@ func (r *request) actionName() string {
 		return r.cachedActionName
 	}
 
-	r.cachedActionName = actionNameFrom(r.request.Method, r.request.URL.EscapedPath())
+	r.cachedActionName = r.middleware.ActionNameExtractor(r.request)
 	return r.cachedActionName
 }
 


### PR DESCRIPTION
The way action names have been derived from the request was somewhat limited. For applications that didn't follow the convention that was assumed the generated action names would be less than ideal.

In our case for example we have random ids as part of the path segment. This means that a lot of different (random) actions are generated, where we really only have one. 

This patch adds the ability to specify a function that is used to extract the action name from the http request. This can be configured in the middleware options and it defaults to the existing implementation.

Another noteworthy change is that the action name is now passed into the logjam request, rather than being computed (and cached) later. As we already have all the required information to do so, this should be safe.

Please let me know what you think. :) 