### PR TITLE
fixed some bugs regarding logjam header handling

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -261,6 +261,7 @@ func SetLogjamHeaders(hasContext HasContext, outgoing *http.Request) {
 			outgoing.Header = http.Header{}
 		}
 		outgoing.Header.Set("X-Logjam-Caller-Id", incoming.id())
+		outgoing.Header.Set("X-Logjam-Action", incoming.actionName)
 	} else {
 		if logger != nil {
 			logger.Println("couldn't set required outgoing headers, expect call sequence issues.\n",

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -313,7 +313,7 @@ func TestMiddleware(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(res.StatusCode, ShouldEqual, 200)
 		So(res.Header.Get("X-Logjam-Request-Id"), ShouldEqual, "appName-envName-"+uuid)
-		So(res.Header.Get("X-Logjam-Request-Action"), ShouldEqual, actionName)
+		So(res.Header.Get("X-Logjam-Action"), ShouldEqual, actionName)
 		So(res.Header.Get("X-Logjam-Caller-Id"), ShouldEqual, callerId)
 		So(res.Header.Get("Http-Authorization"), ShouldEqual, "")
 
@@ -401,8 +401,8 @@ func TestSetLogjamHeaders(t *testing.T) {
 		incomingW := incoming.WithContext(context.WithValue(incoming.Context(), requestKey, wrapped))
 		outgoing := httptest.NewRequest("GET", "/", nil)
 		SetLogjamHeaders(incomingW, outgoing)
-		So(outgoing.Header.Get("X-Logjam-Request-Action"), ShouldEqual, "GET_userdefined")
-		So(outgoing.Header.Get("X-Logjam-Request-Id"), ShouldEqual, "testing-test-f1405ced8b9948bab9109259515bf702")
+		So(outgoing.Header.Get("X-Logjam-Action"), ShouldEqual, "GET_userdefined")
+		So(outgoing.Header.Get("X-Logjam-Caller-Id"), ShouldEqual, "testing-test-f1405ced8b9948bab9109259515bf702")
 	})
 }
 


### PR DESCRIPTION
There is no X-Logjam-Caller-Action, only X-Logjam-Action, so all called services show Unknown#unknown when called from this client.

Caller id and caller action were not sent to logjam, so all callers of this client did show up as Unknown#unknown.